### PR TITLE
Fix invalid deval's output by the hash array that include exclude_key

### DIFF
--- a/lib/dslh.rb
+++ b/lib/dslh.rb
@@ -146,7 +146,7 @@ class Dslh
       if value.any? {|v| [Array, Hash].any? {|c| v.kind_of?(c) }}
         nested = true
 
-        if not @options[:dump_old_hash_array_format] and value.all? {|i| i.kind_of?(Hash) }
+        if not @options[:dump_old_hash_array_format] and value.all? {|i| i.kind_of?(Hash) and not exclude_keys?(i.keys) }
           value_buf.puts(@options[:use_braces_instead_of_do_end] ? ' {|*|' : ' do |*|')
 
           value.each_with_index do |v, i|
@@ -172,9 +172,13 @@ class Dslh
           value.each_with_index do |v, i|
             case v
             when Hash
-              value_buf.puts(next_indent + '_{')
-              deval0(v, depth + 2, value_buf)
-              value_buf.print(next_indent + '}')
+              if exclude_keys?(v.keys)
+                value_buf.print(INDENT_SPACES * (depth + 1) + v.pretty_inspect.strip)
+              else
+                value_buf.puts(next_indent + '_{')
+                deval0(v, depth + 2, value_buf)
+                value_buf.print(next_indent + '}')
+              end
             when Array
               value_buf.print(next_indent.slice(0...-1))
               value_proc(v, depth + 1, value_buf, false)

--- a/spec/dslh_spec.rb
+++ b/spec/dslh_spec.rb
@@ -2680,6 +2680,58 @@ end
     EOS
   end
 
+  it 'should convert hash to dsl (include hash array with exclude_key)' do
+    exclude_key = proc do |k|
+      k == :title
+    end
+
+    h = {:glossary=>[
+          {:title=>"example glossary",
+           :date=>Time.parse('2016/05/21 00:00 UTC').to_s},
+          {:title=>"example glossary2",
+           :date=>Time.parse('2016/05/21 00:01 UTC').to_s}],
+         :glossary2=>[
+          {:title=>"example glossary",
+           :date=>Time.parse('2016/05/21 00:00 UTC').to_s}]}
+
+    dsl = Dslh.deval(h, :exclude_key => exclude_key)
+    expect(dsl).to eq(<<-EOS)
+glossary [
+  {:title=>"example glossary", :date=>"2016-05-21 00:00:00 UTC"},
+  {:title=>"example glossary2", :date=>"2016-05-21 00:01:00 UTC"}
+]
+glossary2 [
+  {:title=>"example glossary", :date=>"2016-05-21 00:00:00 UTC"}
+]
+    EOS
+  end
+
+  it 'should convert hash to dsl (include hash array with exclude_key and dump_old_hash_array_format)' do
+    exclude_key = proc do |k|
+      k == :title
+    end
+
+    h = {:glossary=>[
+          {:title=>"example glossary",
+           :date=>Time.parse('2016/05/21 00:00 UTC').to_s},
+          {:title=>"example glossary2",
+           :date=>Time.parse('2016/05/21 00:01 UTC').to_s}],
+         :glossary2=>[
+          {:title=>"example glossary",
+           :date=>Time.parse('2016/05/21 00:00 UTC').to_s}]}
+
+    dsl = Dslh.deval(h, :exclude_key => exclude_key)
+    expect(dsl).to eq(<<-EOS)
+glossary [
+  {:title=>"example glossary", :date=>"2016-05-21 00:00:00 UTC"},
+  {:title=>"example glossary2", :date=>"2016-05-21 00:01:00 UTC"}
+]
+glossary2 [
+  {:title=>"example glossary", :date=>"2016-05-21 00:00:00 UTC"}
+]
+    EOS
+  end
+
   it 'should convert dsl to hash (include hash array)' do
     h = {:glossary=>[
           {:title=>"example glossary",


### PR DESCRIPTION
Hi,

Thank you as always for your `codenize.tools`

## Sample code

```ruby
require 'dslh'

exclude_key = proc do |k|
  k == 'exclude_key'
end

puts dsl = Dslh.deval(
  {
    'key'=> [
      {'exclude_key'=>'value'},
      {'exclude_key'=>'value'}
    ]
  },
  exclude_key: exclude_key)
puts Dslh.eval(dsl)

puts dsl = Dslh.deval(
  {
    'key'=> [
      {'exclude_key'=>'value'},
      {'exclude_key'=>'value'}
    ]
  },
  exclude_key: exclude_key,
  dump_old_hash_array_format: true)
puts Dslh.eval(dsl)
```

## Result

- Before

```ruby
key do |*|
(
  {"exclude_key"=>"value"})
end
key do |*|
(
  {"exclude_key"=>"value"})
end
{"key"=>[{}, {}]}
key [
  _{
(
    {"exclude_key"=>"value"})
  },
  _{
(
    {"exclude_key"=>"value"})
  }
]
{"key"=>[{}, {}]}
```

- After

```ruby
key [
  {"exclude_key"=>"value"},
  {"exclude_key"=>"value"}
]
{"key"=>[{"exclude_key"=>"value"}, {"exclude_key"=>"value"}]}
key [
  {"exclude_key"=>"value"},
  {"exclude_key"=>"value"}
]
{"key"=>[{"exclude_key"=>"value"}, {"exclude_key"=>"value"}]}
```