### PR TITLE
Add use_heredoc_for_multi_line option

### DIFF
--- a/lib/dslh.rb
+++ b/lib/dslh.rb
@@ -37,6 +37,7 @@ class Dslh
     :time_inspecter,
     :use_braces_instead_of_do_end,
     :value_conv,
+    :use_heredoc_for_multi_line,
   ]
 
   class << self
@@ -83,6 +84,7 @@ class Dslh
       :dump_old_hash_array_format => false,
       :force_dump_braces => false,
       :use_braces_instead_of_do_end => false,
+      :use_heredoc_for_multi_line => false,
     }.merge(options)
 
     @options[:key_conv] ||= (@options[:conv] || proc {|i| i.to_s })
@@ -318,7 +320,13 @@ class Dslh
         value = @options[:time_inspecter].call(value)
         value_buf.puts(' ' + value)
       else
-        value_buf.puts(' ' + value.inspect)
+        if @options[:use_heredoc_for_multi_line] \
+          and value.kind_of?(String) \
+          and value.match(/\R/)
+          value_buf.puts(' ' + "<<-EOS\n#{value}\nEOS")
+        else
+          value_buf.puts(' ' + value.inspect)
+        end
       end
     end
 

--- a/spec/dslh_spec.rb
+++ b/spec/dslh_spec.rb
@@ -545,6 +545,54 @@ end
     EOS
   end
 
+  it 'should convert hash to dsl with use_heredoc_for_multi_line' do
+    h = {"glossary"=>
+          {"title"=>"example glossary",
+           "description" => "example\nglossary",
+           "GlossDiv"=>
+            {"title"=>"S",
+             "GlossList"=>
+              {"GlossEntry"=>
+                {"ID"=>"SGML",
+                 "SortAs"=>"SGML",
+                 "GlossTerm"=>"Standard Generalized Markup Language",
+                 "Acronym"=>"SGML",
+                 "Abbrev"=>"ISO 8879:1986",
+                 "GlossDef"=>
+                  {"para"=>
+                    "A meta-markup language, used to create markup languages such as DocBook.",
+                   "GlossSeeAlso"=>["GML", "XML"]},
+                 "GlossSee"=>"markup"}}}}}
+
+    dsl = Dslh.deval(h, :use_heredoc_for_multi_line => true)
+    expect(dsl).to eq(<<-EOT)
+glossary do
+  title "example glossary"
+  description <<-EOS
+example
+glossary
+EOS
+  GlossDiv do
+    title "S"
+    GlossList do
+      GlossEntry do
+        ID "SGML"
+        SortAs "SGML"
+        GlossTerm "Standard Generalized Markup Language"
+        Acronym "SGML"
+        Abbrev "ISO 8879:1986"
+        GlossDef do
+          para "A meta-markup language, used to create markup languages such as DocBook."
+          GlossSeeAlso "GML", "XML"
+        end
+        GlossSee "markup"
+      end
+    end
+  end
+end
+    EOT
+  end
+
   it 'does not allow duplicate key' do
     expect {
       Dslh.eval do


### PR DESCRIPTION
Add the option to use heredoc for multi-line string.

Example:

```ruby
puts Dslh.deval({"foo" => {"bar" => "buz\nqux"}})
# => foo do
#   bar "buz\nqux"
# end

puts Dslh.deval({"foo" => {"bar" => "buz\nqux"}}, :use_heredoc_for_multi_line => true)
# => foo do
#   bar <<-EOS
# buz
# qux
# EOS
# end

