### PR TITLE
Add quote to heredoc identifier

### DIFF
--- a/lib/dslh.rb
+++ b/lib/dslh.rb
@@ -323,7 +323,7 @@ class Dslh
         if @options[:use_heredoc_for_multi_line] \
           and value.kind_of?(String) \
           and value.match(/\R/)
-          value_buf.puts(' ' + "<<-EOS\n#{value}\nEOS")
+          value_buf.puts(' ' + "<<-'EOS'\n#{value}\nEOS")
         else
           value_buf.puts(' ' + value.inspect)
         end

--- a/spec/dslh_spec.rb
+++ b/spec/dslh_spec.rb
@@ -568,7 +568,7 @@ end
     expect(dsl).to eq(<<-EOT)
 glossary do
   title "example glossary"
-  description <<-EOS
+  description <<-'EOS'
 example
 glossary
 EOS


### PR DESCRIPTION
I found the problem about #6 
The escape sequences should not be changed, but it is not the case with heredocs without quotes.

ref: https://docs.ruby-lang.org/ja/latest/class/String.html